### PR TITLE
Fix SignedAvailabilityBitfield type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,14 @@ In case the apps complain about missing types when registering the parachain via
     "recipient": "Id"
   },
   "ValidatorIndex": "u32",
-  "Signed<AvailabilityBitfield>": {
+  "SignedAvailabilityBitfield": {
     "payload": "AvailabilityBitfield",
     "validator_index": "ValidatorIndex",
     "signature": "ValidatorSignature",
     "real_payload": "PhantomData<AvailabilityBitfield>"
   },
   "AvailabilityBitfield": "BitVec<Lsb0, u8>",
-  "SignedAvailabilityBitfield": "Signed<AvailabilityBitfield>",
-  "SignedAvailabilityBitfields": "Vec<SignedAvailabilityBitfield>"
+  "SignedAvailabilityBitfields": "Vec<SignedAvailabilityBitfield>",
 }
 ```
 


### PR DESCRIPTION
This PR makes some slight changes to the Polkadot JS types listed in the readme. I found that the types listed did not allow me to decode events when registering my the parachain, but the simplified ones I'm suggesting did work.